### PR TITLE
fix: remove italic style in h1

### DIFF
--- a/src/pages/examples/index.tsx
+++ b/src/pages/examples/index.tsx
@@ -205,7 +205,7 @@ export default function Page() {
               xl:text-6xl
             `}
           >
-            <span className="mr-4 italic">Univer Examples</span>
+            <span className="mr-4">Univer Examples</span>
             🎮
           </h1>
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -160,7 +160,7 @@ export default function Page() {
 
           <h1
             className={`
-              mb-7 mt-[60px] text-center text-5xl/tight font-bold italic
+              mb-7 mt-[60px] text-center text-5xl/tight font-bold
 
               xl:mt-0 xl:text-6xl/tight
             `}


### PR DESCRIPTION
Italic is usually not suitable for Chinese characters, especially in titles.